### PR TITLE
Store key for tests in an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ You can either require the whole client enabling you to use every GraphHopper AP
 
 ## Running Tests
 
-You can run all tests via `npm test`. If you only want to run a single spec file, you can use the `--spec` option, e.g., `npm test --spec spec/GraphHopperRoutingSpec.js`.
+In order to run the tests, you have to register for a key on [GraphHopper](https://www.graphhopper.com/).
+Either set your key as environment variable using `export GHKEY=YOUR_KEY` or set your key in `spec/helpers/config.js`.
+You can run all tests via `npm test`. 
+If you only want to run a single spec file, you can use the `--spec` option, e.g., `npm test --spec spec/GraphHopperRoutingSpec.js`.
 
 ## Dependencies
 

--- a/spec/GraphHopperRoutingSpec.js
+++ b/spec/GraphHopperRoutingSpec.js
@@ -123,8 +123,6 @@ describe("Simple Route", function () {
     it("Test Roundtrip", function (done) {
         ghRouting.clearPoints();
         ghRouting.addPoint(new GHInput("48.871028,9.078012"));
-        // tmp fix as the API currently requires two points
-        ghRouting.addPoint(new GHInput(""));
 
         ghRouting.doRequest({round_trip: {distance: 10000, seed: 123}, algorithm: "round_trip"})
             .then(function (json) {

--- a/spec/helpers/config.js
+++ b/spec/helpers/config.js
@@ -1,5 +1,5 @@
-// Sign-up for free and get your own key: https://graphhopper.com/#directions-api
-global.key = "c9b2b65d-be3d-4d96-b19c-48365a066ae3";
+// Sign-up for free key on: https://graphhopper.com/#directions-api
+global.key = process.env.GHKEY;
 global.profile = "car";
 
 // Some tests take longer than the default 5000ms of Jasmine


### PR DESCRIPTION
Fixes #34. 

Currently our Travis tests are failing, because we don't have a valid API KEY registered. This PR proposes to store the key in an environment variable on Travis, but not encrypted, because encrypted environment variables don't work for [PRs](https://docs.travis-ci.com/user/environment-variables/#Defining-encrypted-variables-in-.travis.yml). I registered the variable in travis, so no code changes are required to change the key.